### PR TITLE
Add composite GitHub Action and default exclusions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,70 @@
+name: 'Note Watcher'
+description: 'Process @agent instructions in Obsidian markdown notes and write results back inline'
+author: 'Britt Crawford'
+
+branding:
+  icon: 'eye'
+  color: 'purple'
+
+inputs:
+  vault:
+    description: 'Path to the Obsidian vault (relative to the repository root)'
+    required: false
+    default: '.'
+  config:
+    description: 'Path to the Note Watcher config file (relative to the repository root)'
+    required: false
+    default: 'config.yml'
+  python-version:
+    description: 'Python version to use'
+    required: false
+    default: '3.11'
+  version:
+    description: 'Note Watcher package version to install (e.g. "0.1.0"). Defaults to latest.'
+    required: false
+    default: ''
+  commit:
+    description: 'Whether to commit and push results automatically'
+    required: false
+    default: 'true'
+  commit-message:
+    description: 'Commit message to use when committing results'
+    required: false
+    default: 'Process note instructions [skip ci]'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Note Watcher
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        if [ -n "$VERSION" ]; then
+          pip install "note-watcher==$VERSION"
+        else
+          pip install note-watcher
+        fi
+
+    - name: Process notes
+      shell: bash
+      env:
+        CONFIG: ${{ inputs.config }}
+        VAULT: ${{ inputs.vault }}
+      run: note-watcher process --all --config "$CONFIG" --vault "$VAULT"
+
+    - name: Commit results
+      if: inputs.commit == 'true'
+      shell: bash
+      env:
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+      run: |
+        git config user.name 'Note Watcher Bot'
+        git config user.email 'note-watcher@users.noreply.github.com'
+        git add -A
+        git diff --staged --quiet || git commit -m "$COMMIT_MESSAGE"
+        git push

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,6 +12,10 @@ debounce_seconds: 1.0
 ignore_patterns:
   - "*.excalidraw.md"
   - ".trash/**"
+  - ".obsidian/**"
+  - ".claude/**"
+  - ".git/**"
+  - ".github/**"
 
 # Agent definitions
 agents:

--- a/examples/github-action/.github/workflows/note-watcher.yml
+++ b/examples/github-action/.github/workflows/note-watcher.yml
@@ -8,18 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
       - uses: anthropics/anthropic-cookbook/.github/actions/claude-code@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-      - run: pip install note-watcher
-      - run: note-watcher process --all --vault .
-      - name: Commit results
-        run: |
-          git config user.name 'Note Watcher Bot'
-          git config user.email 'note-watcher@users.noreply.github.com'
-          git add -A
-          git diff --staged --quiet || git commit -m "Process note instructions [skip ci]"
-          git push
+      - uses: britt/obsidian-note-watcher@main
+        with:
+          vault: '.'

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -1,12 +1,12 @@
 # Note Watcher GitHub Action Example
 
-This example shows how to set up Note Watcher as a GitHub Action in your Obsidian notes repository.
+This example shows how to set up Note Watcher as a GitHub Action in your Obsidian notes repository. It uses [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as the agent, but Note Watcher can run any command — `claude -p` is just one option. Any program that reads from stdin and writes to stdout works as a `command` agent (see the [agent types](../../README.md#agent-types) in the main README).
 
 ## Setup
 
 1. Copy `.github/workflows/note-watcher.yml` into your notes repository
 2. Copy `config.example.yml` to `config.yml` in your notes repository root and configure your agents
-3. Add your `ANTHROPIC_API_KEY` as a repository secret under **Settings > Secrets and variables > Actions**
+3. Add your `ANTHROPIC_API_KEY` as a repository secret under **Settings > Secrets and variables > Actions** (only needed for the Claude agent — swap in your own command and secrets as needed)
 4. Under **Settings > Actions > General**, set "Workflow permissions" to "Read and write permissions"
 
 ## How it works
@@ -14,10 +14,20 @@ This example shows how to set up Note Watcher as a GitHub Action in your Obsidia
 When you push changes to `.md` files, the workflow:
 
 1. Checks out your repository
-2. Sets up Python and Claude Code
-3. Installs Note Watcher and processes all unprocessed `@` instructions
-4. Commits the results back using a bot identity
-5. Uses `[skip ci]` to prevent infinite workflow loops
+2. Sets up Claude Code (only needed for the Claude agent in this example)
+3. Runs the `britt/obsidian-note-watcher` action, which installs Note Watcher, processes all unprocessed `@` instructions, and commits the results back
+4. Uses `[skip ci]` to prevent infinite workflow loops
+
+## Action inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `vault` | `.` | Path to the Obsidian vault (relative to repo root) |
+| `config` | `config.yml` | Path to the Note Watcher config file |
+| `python-version` | `3.11` | Python version to use |
+| `version` | latest | Note Watcher package version to install |
+| `commit` | `true` | Whether to commit and push results automatically |
+| `commit-message` | `Process note instructions [skip ci]` | Commit message to use |
 
 ## Example
 

--- a/examples/github-action/config.example.yml
+++ b/examples/github-action/config.example.yml
@@ -8,6 +8,10 @@ vault: .
 ignore_patterns:
   - "*.excalidraw.md"
   - ".trash/**"
+  - ".obsidian/**"
+  - ".claude/**"
+  - ".git/**"
+  - ".github/**"
 
 # Agent definitions
 agents:


### PR DESCRIPTION
Adds a reusable composite GitHub Action for Note Watcher with secure input handling, default exclusion patterns for common directories, and simplifies the example workflow to use the new action.

The action.yml uses environment variables for inputs to prevent shell injection vulnerabilities, while the config examples now exclude .obsidian, .claude, .git, and .github directories by default.

The example workflow has been refactored to use the new action instead of inline steps, and the README has been updated with input documentation and clarification that any stdin/stdout command can be used as an agent.