### PR TITLE
Clarify agent vault-modification workflow in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Note Watcher
 
-A daemon that detects `@` mentions in Obsidian markdown notes, dispatches instructions to configured agents, and writes results back as HTML comments.
+A tool that detects `@` mentions in Obsidian markdown notes stored in Git and dispatches instructions to configured agents — like [Claude Code](https://docs.anthropic.com/en/docs/claude-code) — that can read, modify, and reorganize your notes directly.
 
-Write `@agent_name do something` in any note, and Note Watcher replaces it with the agent's output wrapped in a single HTML comment (invisible in rendered markdown):
+Write `@agent_name do something` in any note, and Note Watcher dispatches the instruction to the named agent. The agent can edit files, create new notes, restructure content, or make any other changes to your vault. The original instruction is then replaced with a completion marker (an HTML comment, invisible in rendered markdown) so it is never reprocessed:
 
 ```markdown
 <!-- @done agent_name: do something
-Agent output goes here.
+Agent response summary goes here.
 /@done -->
 ```
 
-Processed instructions are wrapped in `<!-- @done ... /@done -->` comment blocks so they are never reprocessed and stay hidden when the note is rendered.
+The real work happens in the commit: the agent's changes to your vault are committed back to Git. The completion comment is just a record that the instruction was processed.
 
 ## Modes of Operation
 
@@ -94,10 +94,10 @@ agents:
     command: "claude -p"   # Dispatches instruction to Claude Code CLI
 ```
 
-Then write `@claude` instructions in your notes:
+Claude Code runs with full access to your vault, so it can edit notes, create new files, and reorganize content — not just respond in a comment. Write `@claude` instructions in your notes:
 
 ```markdown
-@claude Summarize the key points of this meeting
+@claude Summarize the key points of this meeting and add action items to my Tasks note
 ```
 
 ## Daemon Mode
@@ -169,7 +169,7 @@ To set it up:
 3. Add your `ANTHROPIC_API_KEY` as a repository secret
 4. Under **Settings > Actions > General**, set "Workflow permissions" to "Read and write permissions"
 
-The workflow triggers on any push that modifies `.md` files, processes all unprocessed `@` instructions, and commits the results back. It uses `[skip ci]` to prevent infinite loops.
+The workflow triggers on any push that modifies `.md` files, processes all unprocessed `@` instructions, and commits the agent's changes back to your repository. It uses `[skip ci]` to prevent infinite loops.
 
 See the [Claude Code GitHub Actions documentation](https://docs.anthropic.com/en/docs/claude-code/github-actions) for more on setting up Claude Code in CI.
 

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -15,8 +15,10 @@ When you push changes to `.md` files, the workflow:
 
 1. Checks out your repository
 2. Sets up Claude Code (only needed for the Claude agent in this example)
-3. Runs the `britt/obsidian-note-watcher` action, which installs Note Watcher, processes all unprocessed `@` instructions, and commits the results back
-4. Uses `[skip ci]` to prevent infinite workflow loops
+3. Runs the `britt/obsidian-note-watcher` action, which installs Note Watcher and processes all unprocessed `@` instructions
+4. The agent (e.g. Claude Code) can read, edit, create, and reorganize notes across your vault — not just reply in a comment
+5. All changes are committed and pushed back to your repository
+6. Uses `[skip ci]` to prevent infinite workflow loops
 
 ## Action inputs
 
@@ -34,13 +36,15 @@ When you push changes to `.md` files, the workflow:
 Write `@claude` instructions in your notes:
 
 ```markdown
-@claude Summarize the key points of this meeting
+@claude Summarize the key points of this meeting and add action items to my Tasks note
 ```
 
-After the workflow runs, it becomes:
+After the workflow runs, Claude Code edits your vault (creating or updating notes as needed), and the original instruction is replaced with a completion marker:
 
 ```markdown
-<!-- @done claude: Summarize the key points of this meeting
-The key points of this meeting are...
+<!-- @done claude: Summarize the key points of this meeting and add action items to my Tasks note
+Added summary and extracted 3 action items to Tasks.md.
 /@done -->
 ```
+
+The completion comment is just a record — the real work is in the commit, where the agent's changes to your notes are pushed back to the repository.


### PR DESCRIPTION
## Summary

Updated README and example documentation to emphasize that the primary workflow is for agents like Claude Code to edit, create, and reorganize notes directly in the vault. The completion comments are processing records that get committed back to Git, not the primary output.

## Changes

- Main README: Reframed the intro to describe agents modifying notes directly, with completion comments as tracking records
- Example action README: Expanded the workflow explanation and updated examples to show vault-wide modifications
- Both docs now clarify that instructions can trigger multi-file changes across the vault, not just inline responses

## Testing

These are documentation-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)