### PR TITLE
Show README content on pdoc index page

### DIFF
--- a/note_watcher/__init__.py
+++ b/note_watcher/__init__.py
@@ -1,3 +1,10 @@
 """Note Watcher - Detect @ mentions in Obsidian notes and dispatch to AI agents."""
 
+from pathlib import Path as _Path
+
 __version__ = "0.1.0"
+
+# Use README.md as the module docstring so pdoc shows it on the index page.
+_readme = _Path(__file__).parent.parent / "README.md"
+if _readme.is_file():
+    __doc__ = _readme.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Load README.md at module import time and set it as the package docstring
- pdoc now displays the full project documentation on the generated index page instead of just the brief module docstring

## Test Results
- All 69 tests passing
- Documentation builds successfully with full README content visible