### PR TITLE
fix: add write permissions to GitHub Action workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ To set it up:
 1. Copy `examples/github-action/.github/` into your notes repository
 2. Add a `config.yml` to your notes repo (see `examples/github-action/config.example.yml`)
 3. Add your `ANTHROPIC_API_KEY` as a repository secret
-4. Under **Settings > Actions > General**, set "Workflow permissions" to "Read and write permissions"
+
+The example workflow already includes `permissions: contents: write`, which is required for the action to push processed results back to your repository. If you write your own workflow, make sure to include this permission block.
 
 The workflow triggers on any push that modifies `.md` files, processes all unprocessed `@` instructions, and commits the agent's changes back to your repository. It uses `[skip ci]` to prevent infinite loops.
 

--- a/examples/github-action/.github/workflows/note-watcher.yml
+++ b/examples/github-action/.github/workflows/note-watcher.yml
@@ -3,6 +3,8 @@ on:
   push:
     paths:
       - '**.md'
+permissions:
+  contents: write
 jobs:
   process:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The note-watcher GitHub Action requires write access to the repository to commit and push processed results. The default `GITHUB_TOKEN` was read-only, causing `git push` to fail with a 403 error.

## Changes

- Added `permissions: contents: write` to the example workflow
- Updated README to clarify the permissions requirement instead of relying on manual UI setup
- This ensures the action works out-of-the-box for new users

## Fixes

Resolves the "fatal: unable to access" error when the action tries to push results to private repositories.