### PR TITLE
fix(parser): ignore trailing punctuation in agent name matching

### DIFF
--- a/note_watcher/parser.py
+++ b/note_watcher/parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 
 
 # Pattern to match @ mention instructions: @agent_name followed by instruction text
-INSTRUCTION_PATTERN = re.compile(r"^@(\w+)\s+(.+)$")
+INSTRUCTION_PATTERN = re.compile(r"^@(\w+)[,:;.]?\s+(.+)$")
 
 # Markers for completed instructions
 # New format: <!-- @done agent_name: instruction text  (no closing -->)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "notes-watcher"
-version = "0.3.0"
+version = "0.3.1"
 description = "A daemon that detects @ mentions in Obsidian notes, dispatches instructions to AI agents, and writes results back inline."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -114,6 +114,24 @@ class TestParseInstructions:
         instructions = parse_instructions(content)
         assert len(instructions) == 1
 
+    def test_agent_name_with_trailing_colon(self) -> None:
+        """@agent: should match agent name 'agent', ignoring the colon."""
+        content = "@echo: hello world"
+        instructions = parse_instructions(content)
+        assert len(instructions) == 1
+        assert instructions[0].agent_name == "echo"
+        assert instructions[0].instruction_text == "hello world"
+
+    def test_agent_name_with_trailing_punctuation(self) -> None:
+        """Trailing punctuation like comma, semicolon, period should be stripped."""
+        for punct in [":", ",", ";", "."]:
+            content = f"@echo{punct} hello world"
+            result = parse_instructions(content)
+            msg = f"Failed for punctuation: {punct}"
+            assert len(result) == 1, msg
+            assert result[0].agent_name == "echo", msg
+            assert result[0].instruction_text == "hello world", msg
+
     def test_at_mention_in_middle_of_line_not_extracted(self) -> None:
         """Only @ mentions at the start of a line are extracted."""
         content = "Contact me at @summarizer for details"


### PR DESCRIPTION
## Summary

Updated the agent name regex pattern to accept optional trailing punctuation (`:`, `,`, `;`, `.`) after agent names. This allows more natural syntax like `@claude: do something` or `@echo, execute this`.

## Changes

- **note_watcher/parser.py**: Modified `INSTRUCTION_PATTERN` regex to accept optional punctuation after agent names
- **tests/test_parser.py**: Added test coverage for colon and other punctuation characters
- **pyproject.toml**: Bumped version to 0.3.1

Fixes the parsing to be more forgiving of natural language punctuation patterns.