### PR TITLE
fix(action): rebase before push for concurrent commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,4 +67,5 @@ runs:
         git config user.email 'note-watcher@users.noreply.github.com'
         git add -A
         git diff --staged --quiet || git commit -m "$COMMIT_MESSAGE"
+        git pull --rebase
         git push


### PR DESCRIPTION
## Summary
- Adds `git pull --rebase` before `git push` in the action's commit step
- Fixes push failures when vault backup commits land on main while the action is processing instructions

## Context
The notes vault receives frequent automated backup pushes. If one lands between `actions/checkout` and the final `git push`, the push is rejected with "Updates were rejected because the remote contains work that you do not have locally." Rebasing first resolves this cleanly.

## Test plan
- [ ] Trigger the action while a vault backup is in flight — push should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)