### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "notes-watcher"
-version = "0.4.1"
+version = "0.4.2"
 description = "A daemon that detects @ mentions in Obsidian notes, dispatches instructions to AI agents, and writes results back inline."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps version to 0.4.2 to publish the `actions/setup-python@v6` upgrade to the marketplace

## Test plan
- [ ] Verify version in pyproject.toml is 0.4.2
- [ ] Merge and tag release

🤖 Generated with [Claude Code](https://claude.com/claude-code)