### PR TITLE
fix: write @done marker even when the agent removes the instruction line (#12)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8,3 +8,13 @@
 - Linting: 22 pre-existing ruff errors (line length, import sorting, unused import); none introduced by this change
 - Completed: 2026-03-23
 - Notes: Fixed _replace_instruction_line to use text-based search instead of line-number matching. Removed dead process_file function. Added integration test for agent file modification during dispatch.
+
+## Task: Fix Done Comments Not Being Added (Issue #12) - COMPLETE
+- Started: 2026-06-15
+- Tests: 138 passing, 0 failing
+- Coverage: Lines: 90% (TOTAL), writer.py: 100%, parser.py: 100%, dispatcher.py: 97%, watcher.py: 75% (remaining misses are the `start_watcher` daemon loop and an `_should_ignore` branch, both pre-existing and unrelated)
+- Build: Successful
+- Linting: 19 pre-existing ruff errors on origin/main (line length, import sorting); none introduced by this change. Repo is not ruff-format-clean on main, so existing multi-line style was preserved to keep the fix focused.
+- Completed: 2026-06-15
+- Notes: Root cause — when a command agent (e.g. Claude Code) followed its instruction and rewrote the note, it removed the original `@agent` line; `_replace_instruction_line` could then no longer find its anchor, raised ValueError, and `process_file_reparse` swallowed it and broke, so no `@done` marker was written. The #24 text-search fallback only handled the line *moving*, not being *removed*.
+  Fix — "replace-before-dispatch": `process_file_reparse` now writes a parser-neutral sentinel (`<!-- note-watcher: processing @agent ... -->`) in place of the instruction *before* dispatch (while the line is guaranteed present), then swaps the sentinel for the `@done`/`@error` marker after dispatch. The swap anchors on the sentinel and appends at EOF if the agent removed it, so the response is never lost. Unknown-agent and unexpected-error paths restore the original instruction for retry. New writer helpers: `format_pending`, `write_pending`, `finalize_result`, `finalize_error`, `restore_instruction` (refactored shared `_replace_line` core). Verified end-to-end via the real CLI with a command agent, including VERIFICATION_PLAN Scenario 6 (2 markers, agent edits preserved, idempotent on re-run).

--- a/note_watcher/watcher.py
+++ b/note_watcher/watcher.py
@@ -20,7 +20,12 @@ from note_watcher.debouncer import Debouncer
 from note_watcher.dispatcher import AgentDispatcher, UnknownAgentError
 from note_watcher.parser import parse_instructions
 from note_watcher.result_validator import AuthFailureError
-from note_watcher.writer import write_error, write_result
+from note_watcher.writer import (
+    finalize_error,
+    finalize_result,
+    restore_instruction,
+    write_pending,
+)
 
 if TYPE_CHECKING:
     from note_watcher.config import Config
@@ -107,14 +112,26 @@ def process_file_reparse(file_path: str, dispatcher: AgentDispatcher) -> int:
             break
 
         instruction = instructions[0]
+        logger.info(
+            "Dispatching @%s: %s",
+            instruction.agent_name,
+            instruction.instruction_text[:50],
+        )
+
+        # Replace the instruction with a sentinel *before* dispatching, while
+        # the instruction line is still guaranteed to be present. The agent may
+        # rewrite the note (including removing the instruction line) during
+        # dispatch, so we anchor on the sentinel rather than the original line
+        # when writing the result back (issue #12).
         try:
-            logger.info(
-                "Dispatching @%s: %s",
-                instruction.agent_name,
-                instruction.instruction_text[:50],
-            )
+            sentinel = write_pending(file_path, instruction)
+        except Exception as e:
+            logger.error("Error preparing instruction: %s", e)
+            break
+
+        try:
             result = dispatcher.dispatch(instruction, file_path=file_path)
-            write_result(file_path, instruction, result)
+            finalize_result(file_path, sentinel, instruction, result)
             processed += 1
             logger.info("Wrote result for @%s", instruction.agent_name)
         except AuthFailureError:
@@ -122,8 +139,9 @@ def process_file_reparse(file_path: str, dispatcher: AgentDispatcher) -> int:
                 "Auth failure for @%s: writing error marker",
                 instruction.agent_name,
             )
-            write_error(
+            finalize_error(
                 file_path,
+                sentinel,
                 instruction,
                 "Arcade authorization required. Re-run scripts/authorize_arcade.py "
                 "to refresh tokens.",
@@ -131,9 +149,11 @@ def process_file_reparse(file_path: str, dispatcher: AgentDispatcher) -> int:
             processed += 1
         except UnknownAgentError as e:
             logger.warning("Skipping unknown agent: %s", e)
+            restore_instruction(file_path, sentinel, instruction)
             break
         except Exception as e:
             logger.error("Error processing instruction: %s", e)
+            restore_instruction(file_path, sentinel, instruction)
             break
 
     return processed

--- a/note_watcher/writer.py
+++ b/note_watcher/writer.py
@@ -44,16 +44,85 @@ def format_error(agent_name: str, instruction_text: str, reason: str) -> str:
     return f"<!-- @error {agent_name}: {instruction_text}\n{reason}\n/@error -->"
 
 
+def format_pending(agent_name: str, instruction_text: str) -> str:
+    """Format a pending marker written in place of an instruction while it runs.
+
+    The marker is intentionally parser-neutral (it is not a @done, @error, or
+    @agent line) so the parser ignores it, and it carries the agent name and
+    instruction text so it can be located again after dispatch.
+
+    Args:
+        agent_name: Name of the agent that is processing the instruction.
+        instruction_text: The original instruction text from the @ mention.
+
+    Returns:
+        A single-line HTML comment sentinel.
+    """
+    return f"<!-- note-watcher: processing @{agent_name} {instruction_text} -->"
+
+
+def _replace_line(
+    file_path: str | Path,
+    target_text: str,
+    replacement: str,
+    line_number_hint: int | None = None,
+    append_if_missing: bool = False,
+) -> None:
+    """Replace a single line matching ``target_text`` with ``replacement``.
+
+    First attempts a line-number match (fast path) when a hint is given. If the
+    file has been modified since parsing (e.g., by an agent during dispatch),
+    falls back to searching for the target text on any line.
+
+    Args:
+        file_path: Path to the markdown file.
+        target_text: The exact (stripped) line text to replace.
+        replacement: The text to replace the matched line with.
+        line_number_hint: Optional 1-indexed line to check first.
+        append_if_missing: If True, append the replacement at the end of the
+            file when no matching line is found instead of raising.
+
+    Raises:
+        ValueError: If the target text is not found and ``append_if_missing``
+            is False.
+    """
+    path = Path(file_path)
+    content = path.read_text()
+    lines = content.split("\n")
+
+    target = target_text.strip()
+
+    # Fast path: check the hinted line number.
+    if line_number_hint is not None:
+        idx = line_number_hint - 1
+        if 0 <= idx < len(lines) and lines[idx].strip() == target:
+            lines[idx] = replacement
+            path.write_text("\n".join(lines))
+            return
+
+    # Fallback: search all lines for the target text.
+    for i, line in enumerate(lines):
+        if line.strip() == target:
+            lines[i] = replacement
+            path.write_text("\n".join(lines))
+            return
+
+    if append_if_missing:
+        # The line is gone (an agent rewrote it away). Append the replacement
+        # at the end of the file so the result is never lost.
+        prefix = content if content.endswith("\n") or content == "" else content + "\n"
+        path.write_text(prefix + replacement + "\n")
+        return
+
+    raise ValueError(f"Instruction {target!r} not found in file {file_path}")
+
+
 def _replace_instruction_line(
     file_path: str | Path,
     instruction: Instruction,
     replacement: str,
 ) -> None:
     """Replace an instruction line in a file with a replacement string.
-
-    First attempts line-number match (fast path). If the file has been
-    modified since parsing (e.g., by an agent during dispatch), falls back
-    to searching for the instruction text on any line.
 
     Args:
         file_path: Path to the markdown file.
@@ -63,27 +132,12 @@ def _replace_instruction_line(
     Raises:
         ValueError: If the instruction text is not found anywhere in the file.
     """
-    path = Path(file_path)
-    content = path.read_text()
-    lines = content.split("\n")
-
-    target_text = instruction.original_text.strip()
-
-    # Fast path: check original line number
-    line_idx = instruction.line_number - 1
-    if 0 <= line_idx < len(lines) and lines[line_idx].strip() == target_text:
-        lines[line_idx] = replacement
-        path.write_text("\n".join(lines))
-        return
-
-    # Fallback: search all lines for the instruction text
-    for i, line in enumerate(lines):
-        if line.strip() == target_text:
-            lines[i] = replacement
-            path.write_text("\n".join(lines))
-            return
-
-    raise ValueError(f"Instruction {target_text!r} not found in file {file_path}")
+    _replace_line(
+        file_path,
+        instruction.original_text,
+        replacement,
+        line_number_hint=instruction.line_number,
+    )
 
 
 def write_result(
@@ -120,3 +174,88 @@ def write_error(
         instruction.agent_name, instruction.instruction_text, reason
     )
     _replace_instruction_line(file_path, instruction, formatted)
+
+
+def write_pending(file_path: str | Path, instruction: Instruction) -> str:
+    """Replace an instruction with a pending sentinel before dispatch.
+
+    This is done *before* the agent runs, while the instruction line is still
+    guaranteed to be present. The returned sentinel is later swapped for the
+    final result or error marker, which is robust even if the agent rewrites
+    the surrounding note content (issue #12).
+
+    Args:
+        file_path: Path to the markdown file.
+        instruction: The instruction about to be dispatched.
+
+    Returns:
+        The sentinel string written into the file.
+    """
+    sentinel = format_pending(instruction.agent_name, instruction.instruction_text)
+    _replace_instruction_line(file_path, instruction, sentinel)
+    return sentinel
+
+
+def finalize_result(
+    file_path: str | Path,
+    sentinel: str,
+    instruction: Instruction,
+    result: str,
+) -> None:
+    """Replace a pending sentinel with the agent's completed result marker.
+
+    Falls back to appending at the end of the file if the agent removed the
+    sentinel during dispatch, so the result is never lost.
+
+    Args:
+        file_path: Path to the markdown file.
+        sentinel: The sentinel previously written by ``write_pending``.
+        instruction: The original instruction that was processed.
+        result: The agent's output text.
+    """
+    formatted = format_result(
+        instruction.agent_name, instruction.instruction_text, result
+    )
+    _replace_line(file_path, sentinel, formatted, append_if_missing=True)
+
+
+def finalize_error(
+    file_path: str | Path,
+    sentinel: str,
+    instruction: Instruction,
+    reason: str,
+) -> None:
+    """Replace a pending sentinel with an error marker.
+
+    Falls back to appending at the end of the file if the sentinel is gone.
+
+    Args:
+        file_path: Path to the markdown file.
+        sentinel: The sentinel previously written by ``write_pending``.
+        instruction: The original instruction that failed.
+        reason: The reason for the error.
+    """
+    formatted = format_error(
+        instruction.agent_name, instruction.instruction_text, reason
+    )
+    _replace_line(file_path, sentinel, formatted, append_if_missing=True)
+
+
+def restore_instruction(
+    file_path: str | Path,
+    sentinel: str,
+    instruction: Instruction,
+) -> None:
+    """Restore the original instruction in place of a pending sentinel.
+
+    Used when dispatch fails in a way that should leave the instruction for a
+    later retry (e.g. an unknown agent) rather than marking it complete.
+
+    Args:
+        file_path: Path to the markdown file.
+        sentinel: The sentinel previously written by ``write_pending``.
+        instruction: The original instruction to restore.
+    """
+    _replace_line(
+        file_path, sentinel, instruction.original_text, append_if_missing=True
+    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -226,3 +226,44 @@ class TestEndToEnd:
         assert final.count("/@done -->") == 2
         assert "Reformat the meetings column" in final
         assert "SUMMARIZE THE REVIEW" in final
+
+    def test_done_marker_written_when_agent_removes_instruction_line(
+        self, tmp_path: Path, dispatcher: AgentDispatcher
+    ) -> None:
+        """Issue #12: an agent that follows its instruction well and rewrites
+        the note (removing the original @instruction line) still gets a @done
+        marker with its response written back."""
+        note = tmp_path / "note.md"
+        note.write_text(
+            "# Weekly Review\n"
+            "\n"
+            "@echo reformat the meetings section\n"
+            "\n"
+            "Notes here.\n"
+        )
+
+        def rewriting_dispatch(instruction, **kwargs):
+            # Agent rewrites the note, consuming the original @echo line.
+            note.write_text(
+                "# Weekly Review\n"
+                "\n"
+                "## Meetings (reformatted)\n"
+                "\n"
+                "Notes here.\n"
+            )
+            return "AGENT_RESPONSE_TEXT"
+
+        with patch.object(dispatcher, "dispatch", side_effect=rewriting_dispatch):
+            count = process_file_reparse(str(note), dispatcher)
+
+        final = note.read_text()
+        # The agent's modifications are preserved.
+        assert "## Meetings (reformatted)" in final
+        # The completion marker is written and the response is pasted in.
+        assert count == 1
+        assert final.count("<!-- @done") == 1
+        assert "<!-- @done echo: reformat the meetings section" in final
+        assert "AGENT_RESPONSE_TEXT" in final
+        assert "/@done -->" in final
+        # No raw instruction remains.
+        assert "@echo reformat the meetings section" not in final

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -208,3 +208,48 @@ class TestProcessFileReparse:
         content = note.read_text()
         assert "<!-- @error echo: First task" in content
         assert "<!-- @done echo: Second task" in content
+
+    def test_unknown_agent_leaves_instruction_for_retry(
+        self, tmp_path: Path, dispatcher: AgentDispatcher
+    ) -> None:
+        """Unknown agents leave the instruction intact (no sentinel/marker)."""
+        note = tmp_path / "note.md"
+        note.write_text("# Title\n\n@nonexistent do a thing\n")
+
+        count = process_file_reparse(str(note), dispatcher)
+
+        assert count == 0
+        content = note.read_text()
+        assert "@nonexistent do a thing" in content
+        assert "note-watcher: processing" not in content
+        assert "<!-- @done" not in content
+
+    def test_dispatch_error_leaves_instruction_for_retry(
+        self, tmp_path: Path, dispatcher: AgentDispatcher
+    ) -> None:
+        """An unexpected dispatch error restores the instruction for retry."""
+        note = tmp_path / "note.md"
+        note.write_text("@echo do a thing\n")
+
+        with patch.object(dispatcher, "dispatch", side_effect=RuntimeError("boom")):
+            count = process_file_reparse(str(note), dispatcher)
+
+        assert count == 0
+        content = note.read_text()
+        assert "@echo do a thing" in content
+        assert "note-watcher: processing" not in content
+
+    def test_break_when_pending_write_fails(
+        self, tmp_path: Path, dispatcher: AgentDispatcher
+    ) -> None:
+        """If the sentinel can't be written, processing stops without crashing."""
+        note = tmp_path / "note.md"
+        note.write_text("@echo do a thing\n")
+
+        with patch(
+            "note_watcher.watcher.write_pending",
+            side_effect=ValueError("cannot write"),
+        ):
+            count = process_file_reparse(str(note), dispatcher)
+
+        assert count == 0

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,7 +3,17 @@
 import pytest
 
 from note_watcher.parser import Instruction, parse_instructions
-from note_watcher.writer import format_error, format_result, write_error, write_result
+from note_watcher.writer import (
+    finalize_error,
+    finalize_result,
+    format_error,
+    format_pending,
+    format_result,
+    restore_instruction,
+    write_error,
+    write_pending,
+    write_result,
+)
 
 
 class TestFormatResult:
@@ -266,3 +276,104 @@ class TestReplaceInstructionAfterFileModification:
         assert "<!-- @error echo: Hello world" in final
         assert "/@error -->" in final
         assert "@echo Hello world" not in final
+
+
+class TestFormatPending:
+    """Tests for format_pending()."""
+
+    def test_sentinel_is_a_single_line_comment(self) -> None:
+        sentinel = format_pending("echo", "do something")
+        assert sentinel == "<!-- note-watcher: processing @echo do something -->"
+        assert "\n" not in sentinel
+
+    def test_sentinel_is_not_parsed_as_instruction(self) -> None:
+        """The pending sentinel must be ignored by the parser."""
+        sentinel = format_pending("echo", "do something")
+        assert parse_instructions(sentinel) == []
+
+
+class TestPendingLifecycle:
+    """Tests for write_pending / finalize_result / finalize_error / restore."""
+
+    def _instruction(self) -> Instruction:
+        return Instruction(
+            agent_name="echo",
+            instruction_text="Hello world",
+            line_number=2,
+            original_text="@echo Hello world",
+        )
+
+    def test_write_pending_replaces_instruction_with_sentinel(self, tmp_path):
+        note = tmp_path / "note.md"
+        note.write_text("# Title\n@echo Hello world\nMore\n")
+
+        sentinel = write_pending(str(note), self._instruction())
+
+        content = note.read_text()
+        assert sentinel in content
+        # The original instruction line is gone, and the sentinel that replaced
+        # it must not be re-parsed as a live instruction.
+        assert "\n@echo Hello world\n" not in content
+        assert parse_instructions(content) == []
+
+    def test_finalize_result_replaces_sentinel_in_place(self, tmp_path):
+        note = tmp_path / "note.md"
+        instruction = self._instruction()
+        note.write_text("# Title\n@echo Hello world\nMore\n")
+        sentinel = write_pending(str(note), instruction)
+
+        finalize_result(str(note), sentinel, instruction, "THE RESULT")
+
+        content = note.read_text()
+        assert sentinel not in content
+        assert "<!-- @done echo: Hello world" in content
+        assert "THE RESULT" in content
+        assert "/@done -->" in content
+        # Result lands where the instruction was, surrounding text preserved.
+        assert "# Title" in content
+        assert "More" in content
+
+    def test_finalize_result_appends_when_sentinel_removed(self, tmp_path):
+        """If the agent deleted the sentinel, the result is appended, not lost."""
+        note = tmp_path / "note.md"
+        instruction = self._instruction()
+        note.write_text("@echo Hello world\n")
+        write_pending(str(note), instruction)
+        sentinel = format_pending("echo", "Hello world")
+
+        # Agent rewrote the whole file, removing the sentinel.
+        note.write_text("Completely new content from the agent.\n")
+
+        finalize_result(str(note), sentinel, instruction, "THE RESULT")
+
+        content = note.read_text()
+        assert "Completely new content from the agent." in content
+        assert "<!-- @done echo: Hello world" in content
+        assert "THE RESULT" in content
+        assert "/@done -->" in content
+
+    def test_finalize_error_replaces_sentinel(self, tmp_path):
+        note = tmp_path / "note.md"
+        instruction = self._instruction()
+        note.write_text("@echo Hello world\n")
+        sentinel = write_pending(str(note), instruction)
+
+        finalize_error(str(note), sentinel, instruction, "Auth required")
+
+        content = note.read_text()
+        assert sentinel not in content
+        assert "<!-- @error echo: Hello world" in content
+        assert "Auth required" in content
+        assert "/@error -->" in content
+
+    def test_restore_instruction_puts_original_back(self, tmp_path):
+        note = tmp_path / "note.md"
+        instruction = self._instruction()
+        note.write_text("@echo Hello world\n")
+        sentinel = write_pending(str(note), instruction)
+
+        restore_instruction(str(note), sentinel, instruction)
+
+        content = note.read_text()
+        assert sentinel not in content
+        assert "@echo Hello world" in content


### PR DESCRIPTION
Fixes #12, where the agent did the work but no longer commented out the instruction or pasted in its response. Root cause: when a command agent (e.g. Claude Code) rewrote the note and removed the original `@agent` line, the writer could no longer find its anchor, raised `ValueError`, and `process_file_reparse` swallowed it and stopped — so no `@done` marker was written. This adopts a "replace-before-dispatch" approach: a parser-neutral sentinel replaces the instruction before dispatch (while the line is guaranteed present), then is swapped for the `@done`/`@error` marker afterward, appending at EOF if the agent removed it so the response is never lost (unknown-agent/unexpected-error paths restore the instruction for retry). Verified via 138 passing tests and end-to-end through the real CLI, including VERIFICATION_PLAN Scenario 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)