### PR TITLE
Automate releases, tie the action to its package version, and modernize workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
@@ -17,7 +17,7 @@ jobs:
       - name: Run tests with coverage
         run: pytest --cov=note_watcher --cov-report=term --cov-report=markdown:coverage.md
       - name: Post coverage comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: coverage
           path: coverage.md

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,8 +9,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.13'
       - run: pip install -e ".[dev]"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - run: pip install -e ".[dev]"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,13 +17,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - run: pip install -e ".[dev]"
       - run: pdoc note_watcher -o docs
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
@@ -35,4 +35,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish to PyPI
 on:
+  push:
+    tags:
+      - 'v*'
   release:
     types: [published]
 jobs:
@@ -9,7 +12,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
       - run: pip install build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+name: Create GitHub Release
+on:
+  push:
+    tags:
+      - 'v*'
+permissions:
+  contents: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish release for ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --title "$TAG" --generate-notes

--- a/action.yml
+++ b/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     default: '3.11'
   version:
-    description: 'notes-watcher package version to install (e.g. "0.1.0"). Defaults to latest.'
+    description: 'notes-watcher package version to install (e.g. "0.1.0"). Defaults to the version matching this action release; use "latest" to always install the newest release.'
     required: false
-    default: ''
+    default: '0.4.3'
   commit:
     description: 'Whether to commit and push results automatically'
     required: false
@@ -44,10 +44,10 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
       run: |
-        if [ -n "$VERSION" ]; then
-          pip install "notes-watcher==$VERSION"
-        else
+        if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
           pip install notes-watcher
+        else
+          pip install "notes-watcher==$VERSION"
         fi
 
     - name: Process notes

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/examples/github-action/.github/workflows/note-watcher.yml
+++ b/examples/github-action/.github/workflows/note-watcher.yml
@@ -9,7 +9,7 @@ jobs:
   process:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: anthropics/anthropic-cookbook/.github/actions/claude-code@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/github-action/.github/workflows/note-watcher.yml
+++ b/examples/github-action/.github/workflows/note-watcher.yml
@@ -9,10 +9,10 @@ jobs:
   process:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: anthropics/anthropic-cookbook/.github/actions/claude-code@main
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-      - uses: britt/obsidian-note-watcher@main
+      - uses: britt/obsidian-notes-watcher@main
         with:
           vault: '.'

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -15,7 +15,7 @@ When you push changes to `.md` files, the workflow:
 
 1. Checks out your repository
 2. Sets up Claude Code (only needed for the Claude agent in this example)
-3. Runs the `britt/obsidian-note-watcher` action, which installs Note Watcher and processes all unprocessed `@` instructions
+3. Runs the `britt/obsidian-notes-watcher` action, which installs Note Watcher and processes all unprocessed `@` instructions
 4. The agent (e.g. Claude Code) can read, edit, create, and reorganize notes across your vault — not just reply in a comment
 5. All changes are committed and pushed back to your repository
 6. Uses `[skip ci]` to prevent infinite workflow loops

--- a/examples/github-action/README.md
+++ b/examples/github-action/README.md
@@ -27,7 +27,7 @@ When you push changes to `.md` files, the workflow:
 | `vault` | `.` | Path to the Obsidian vault (relative to repo root) |
 | `config` | `config.yml` | Path to the Note Watcher config file |
 | `python-version` | `3.11` | Python version to use |
-| `version` | latest | Note Watcher package version to install |
+| `version` | matches the action release | Note Watcher package version to install; use `latest` to track the newest release |
 | `commit` | `true` | Whether to commit and push results automatically |
 | `commit-message` | `Process note instructions [skip ci]` | Commit message to use |
 

--- a/tests/test_action_metadata.py
+++ b/tests/test_action_metadata.py
@@ -1,0 +1,58 @@
+"""Tests for the composite GitHub Action metadata in action.yml.
+
+The action pip-installs the ``notes-watcher`` package at runtime. If the
+version it installs is not tied to the action release, a consumer pinned to
+``@v0.4.3`` silently runs whatever is newest on PyPI.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _package_version() -> str:
+    """Read the package version from pyproject.toml.
+
+    Parsed with a regex rather than ``tomllib`` so the test also runs on
+    Python 3.10, which the CI matrix still covers.
+    """
+    text = (REPO_ROOT / "pyproject.toml").read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "no version found in pyproject.toml"
+    return match.group(1)
+
+
+def _action_metadata() -> dict:
+    return yaml.safe_load((REPO_ROOT / "action.yml").read_text())
+
+
+def test_action_version_input_defaults_to_package_version() -> None:
+    """The action installs its own release version by default."""
+    default = _action_metadata()["inputs"]["version"]["default"]
+
+    assert default == _package_version()
+
+
+def _install_step_script() -> str:
+    steps = _action_metadata()["runs"]["steps"]
+    install = next(s for s in steps if s.get("name") == "Install Note Watcher")
+    return install["run"]
+
+
+def test_install_step_treats_latest_as_unpinned() -> None:
+    """Consumers can opt out of the pin and track the newest release."""
+    script = _install_step_script()
+
+    assert "latest" in script, "install step has no 'latest' opt-out branch"
+
+
+def test_install_step_pins_the_requested_version() -> None:
+    """Any other version value installs that exact release."""
+    script = _install_step_script()
+
+    assert "notes-watcher==$VERSION" in script


### PR DESCRIPTION
Pushing a `v*` tag now creates and publishes a GitHub Release (`release.yml`), and `publish.yml` gained a `push: tags` trigger because a release created by `GITHUB_TOKEN` does not emit a `release: published` event — without it the PyPI job would never fire. `action.yml` no longer runs `pip install notes-watcher` unpinned: the `version` input defaults to the action's own release version, so a consumer pinned to `@v0.4.3` gets package 0.4.3 rather than whatever is newest on PyPI, with `latest` available as an opt-out. Every action was moved to its latest major — `checkout` v4→v7, `setup-python` v6→v7, `deploy-pages` v4→v5, `upload-pages-artifact` v3→v5, `sticky-pull-request-comment` v2→v3 — which also clears every deprecated Node 20 runtime, including the one bundled transitively inside `upload-pages-artifact`. Finally, the shipped example referenced `britt/obsidian-note-watcher`, which 404s; it is now the real `britt/obsidian-notes-watcher`.

## Test plan
- [x] 154 tests passing (151 existing + 3 new in `tests/test_action_metadata.py`)
- [x] All workflow YAML parses; every pinned ref verified against its published `action.yml` and releases API — no `node20` runtimes remain
- [x] Install step exercised for `VERSION=""`, `"latest"`, and `"0.4.3"`
- [ ] Note: `examples/.../note-watcher.yml` still references `anthropics/anthropic-cookbook/.github/actions/claude-code@main`, which also 404s — left alone because the fix depends on intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)