### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   version:
     description: 'notes-watcher package version to install (e.g. "0.1.0"). Defaults to the version matching this action release; use "latest" to always install the newest release.'
     required: false
-    default: '0.4.3'
+    default: '0.4.4'
   commit:
     description: 'Whether to commit and push results automatically'
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "notes-watcher"
-version = "0.4.3"
+version = "0.4.4"
 description = "A daemon that detects @ mentions in Obsidian notes, dispatches instructions to AI agents, and writes results back inline."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump package version from 0.4.3 to 0.4.4 (patch release, following the #32 timeout-handling fix).
- Update `action.yml`'s default `version` input to match, per the convention established in #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)