### PR TITLE
fix(action): queue overlapping runs and resync before processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ To set it up:
 
 The example workflow already includes `permissions: contents: write`, which is required for the action to push processed results back to your repository. If you write your own workflow, make sure to include this permission block.
 
+The example workflow also includes a `concurrency` group keyed on the branch, with `cancel-in-progress: false`. This queues runs triggered by rapid, overlapping pushes instead of letting them race to commit at the same time — without it, a push that lands while a prior run is still processing can make that later run's commit fail. If you write your own workflow, include this too:
+
+```yaml
+concurrency:
+  group: note-watcher-${{ github.ref }}
+  cancel-in-progress: false
+```
+
 The workflow triggers on any push that modifies `.md` files, processes all unprocessed `@` instructions, and commits the agent's changes back to your repository. It uses `[skip ci]` to prevent infinite loops.
 
 See the [Claude Code GitHub Actions documentation](https://docs.anthropic.com/en/docs/claude-code/github-actions) for more on setting up Claude Code in CI.

--- a/README.md
+++ b/README.md
@@ -237,6 +237,23 @@ concurrency:
 
 The workflow triggers on any push that modifies `.md` files, processes all unprocessed `@` instructions, and commits the agent's changes back to your repository. It uses `[skip ci]` to prevent infinite loops.
 
+### Upgrading an existing installation to fix overlapping-push failures
+
+If you installed this workflow before the `concurrency` block above was added, a push with an `@mention` that lands while an earlier `@mention` push is still processing can make the later run fail (issue #28). To fix an existing installation:
+
+1. Open the workflow file you copied into your notes repository (e.g. `.github/workflows/note-watcher.yml`).
+2. Add the `concurrency` block shown above, at the top level of the workflow (alongside `on:` and `permissions:`, not inside `jobs:`):
+   ```yaml
+   concurrency:
+     group: note-watcher-${{ github.ref }}
+     cancel-in-progress: false
+   ```
+   This part only lives in your own workflow file — the action can't set it on your behalf — so it always requires this manual edit, no matter how you reference the action below.
+3. Check how your workflow references the action:
+   - `uses: britt/obsidian-notes-watcher@main` — no further action needed. The other half of the fix (resyncing before processing) lives in `action.yml` itself and takes effect automatically on your next run once it's merged to `main`.
+   - `uses: britt/obsidian-notes-watcher@v0.4.x` (or any other pinned tag/SHA) — bump the pin to a release that includes this fix (v0.4.5 or later) once one is published.
+4. Commit and push the workflow change. No config or vault changes are needed.
+
 See the [Claude Code GitHub Actions documentation](https://docs.anthropic.com/en/docs/claude-code/github-actions) for more on setting up Claude Code in CI.
 
 ## Arcade MCP Integration

--- a/VERIFICATION_PLAN.md
+++ b/VERIFICATION_PLAN.md
@@ -137,6 +137,26 @@
 
 **If Blocked**: Verify the command agent actually modifies the file during dispatch. Check that `_replace_instruction_line` falls back to text-based search when line numbers shift.
 
+### Scenario 7: Overlapping GitHub Action Runs Don't Fail (Issue #28)
+
+**Context**: A real notes repository on GitHub with the example workflow (`examples/github-action/.github/workflows/note-watcher.yml`) installed, `ANTHROPIC_API_KEY` configured, and a real `command` agent (e.g. Claude Code) that modifies the note file. This requires live GitHub Actions infrastructure and is performed manually by a developer with push access to such a repo (see Scenario 3/6 for the same real-infra constraint).
+
+**Steps**:
+1. Push a commit adding `@claude first task` to a tracked `.md` file.
+2. While the resulting Action run is still in progress (check the Actions tab), push a second commit adding `@claude second task` to the same file.
+3. Wait for both Action runs to complete.
+4. Read the file and check both run's conclusions in the Actions tab.
+
+**Success Criteria**:
+- [ ] Both Action runs conclude successfully (no red X on either run)
+- [ ] The second run's job was queued behind the first (Actions tab shows it waiting, not executing concurrently) rather than being cancelled
+- [ ] Both `@claude` instructions end up replaced with `<!-- @done ... /@done -->` markers
+- [ ] The first run's in-progress work was not abandoned or duplicated by the second run
+
+**If Blocked**: Ask developer for a test repository with GitHub Actions and `ANTHROPIC_API_KEY` configured.
+
+**Local simulation (automatable, no live Actions needed)**: Since spinning up real overlapping Action runs isn't possible in this environment, the underlying git race that causes the failure was reproduced and fixed locally with two real git clones racing to commit and push conflicting edits to the same lines of a shared bare remote — see the verification log for command output. This exercises the exact `git pull --rebase` / push failure mode described in the issue without needing live GitHub Actions infrastructure.
+
 ## Verification Rules
 
 - Never use mocks or fakes

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,11 @@ runs:
       env:
         CONFIG: ${{ inputs.config }}
         VAULT: ${{ inputs.vault }}
-      run: note-watcher process --all --config "$CONFIG" --vault "$VAULT"
+      run: |
+        # Sync to the branch tip (checkout pins to the triggering SHA) so a run
+        # queued behind another doesn't reprocess instructions it already committed.
+        git pull --ff-only
+        note-watcher process --all --config "$CONFIG" --vault "$VAULT"
 
     - name: Commit results
       if: inputs.commit == 'true'

--- a/design/plans/2026-08-08-concurrent-action-runs-plan.md
+++ b/design/plans/2026-08-08-concurrent-action-runs-plan.md
@@ -1,0 +1,78 @@
+# Issue #28: GitHub Action fails on overlapping pushes with @mentions
+
+## Acceptance criteria (restated from the issue)
+
+1. Pushing an `@mention` while an action run from a *prior* `@mention` push is
+   still in progress must not cause the later run to fail.
+2. Both instructions must end up processed and committed — no instruction is
+   silently lost or double-processed in a way that corrupts the note.
+3. The fix must not abandon or cancel an in-progress agent run (losing partial
+   work) to achieve (1).
+
+## Root cause
+
+`action.yml`'s "Commit results" step already rebases before pushing
+(#15), but that only fixes *unrelated* commits landing on `main` mid-run.
+Issue #28 is two runs of the *same* workflow racing:
+
+- `actions/checkout` pins each run to the exact SHA that triggered it
+  (`github.sha`), not the branch tip. So when push B fires while push A's
+  run is still going, run B's checkout still shows mention 1 as raw/unprocessed
+  (run A hasn't committed its result yet).
+- Without a `concurrency` group, runs A and B execute their "Process notes"
+  step in parallel. Both see mention 1 as unprocessed and both dispatch an
+  agent for it, in addition to run B dispatching for mention 2.
+- When both try to commit, run A pushes first. Run B's `git pull --rebase`
+  then has to replay run B's local commit (which independently reprocessed
+  mention 1) on top of run A's already-pushed commit (which also processed
+  mention 1). Both edited the same lines of the note differently, so the
+  rebase hits a real content conflict and fails — which fails the job.
+
+Two independent gaps, both required to close the race:
+
+- **No concurrency control**: overlapping workflow runs are allowed to
+  execute (and race to push) at the same time.
+- **Stale processing input**: even a run that starts later doesn't re-sync
+  to the branch tip before processing, so it can't see that another run
+  already finished mention 1.
+
+## Fix
+
+1. `examples/github-action/.github/workflows/note-watcher.yml`: add a
+   `concurrency` group keyed on the ref with `cancel-in-progress: false`, so
+   overlapping runs on the same branch queue instead of racing. `false` is
+   required — cancelling an in-progress run would abandon an agent mid-edit
+   (violates acceptance criterion 3).
+2. `action.yml`: in the "Process notes" step, `git pull --ff-only` before
+   running `note-watcher process --all`. Combined with (1), a queued run now
+   starts only after the prior run's commit has landed, and this pull syncs
+   the checkout to see it — so it only dispatches for the mention(s) that are
+   actually still unprocessed. Processing is already idempotent (verified by
+   existing VERIFICATION_PLAN scenarios 5/6: a `@done`-marked instruction is
+   skipped), so this is safe.
+3. `README.md`: document the concurrency requirement in the "Setting up the
+   GitHub Actions workflow" section, since anyone hand-writing their own
+   workflow (not copying the example) needs to add it themselves — same
+   treatment already given to the `permissions: contents: write` requirement.
+
+## Files touched
+
+- `examples/github-action/.github/workflows/note-watcher.yml`
+- `action.yml`
+- `README.md`
+- `VERIFICATION_PLAN.md` (new scenario)
+
+## Assumptions
+
+- "the action fails" in the issue refers to the job exiting non-zero (visible
+  as a red X), which the rebase-conflict path in the root cause above
+  produces. No other failure mode was reported in the issue or comments.
+- A per-ref concurrency group (`note-watcher-${{ github.ref }}`) is the
+  correct granularity — different branches/vaults pushing concurrently are
+  unrelated and shouldn't queue behind each other.
+- Live verification against real GitHub Actions infrastructure (real
+  secrets, real runners) is out of scope for this environment; verification
+  instead uses a local git simulation of the race (real git, no mocks) plus
+  a new manual VERIFICATION_PLAN scenario for a developer with a live test
+  vault, consistent with how existing scenarios 3 and 6 already require
+  manual execution.

--- a/examples/github-action/.github/workflows/note-watcher.yml
+++ b/examples/github-action/.github/workflows/note-watcher.yml
@@ -5,6 +5,9 @@ on:
       - '**.md'
 permissions:
   contents: write
+concurrency:
+  group: note-watcher-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   process:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes #28. Pushing an `@mention` while an earlier `@mention` push's action run was still processing made the later run's job fail.

**Root cause**: `actions/checkout` pins each run to the exact SHA that triggered it, not the branch tip, so an overlapping run's "Process notes" step couldn't see that another run had already committed its result — it would independently reprocess the same instruction. When both runs then tried to push, `git pull --rebase` had to reconcile two different bot commits that edited the same lines of the note, which is a genuine content conflict, not something rebase can auto-resolve. The job fails.

**Fix** (two parts, both required — neither alone closes the race):
1. `examples/github-action/.github/workflows/note-watcher.yml`: add a `concurrency` group (`note-watcher-${{ github.ref }}`, `cancel-in-progress: false`) so overlapping runs on the same ref queue instead of racing to commit. `cancel-in-progress: false` is deliberate — cancelling an in-progress run would abandon a mid-edit agent invocation.
2. `action.yml`: `git pull --ff-only` at the start of the "Process notes" step, so a run that was queued behind another resyncs to the branch tip before dispatching — it then only processes instructions that are genuinely still unprocessed, since processing is already idempotent (`@done`-marked instructions are skipped).
3. `README.md`: documents the `concurrency` block for anyone hand-writing their own workflow instead of copying the example (same treatment as the existing `permissions: contents: write` callout).

Design notes: `design/plans/2026-08-08-concurrent-action-runs-plan.md`

## Assumptions

- "the action fails" means the job exits non-zero (red X in the Actions tab), produced by the rebase-conflict path described above — no other failure mode was reported in the issue (no comments on it).
- Per-ref concurrency grouping is the right granularity; different branches racing is unrelated and shouldn't queue behind each other.
- Live verification against real GitHub Actions infrastructure (real secrets, real overlapping runs) is out of scope for this environment. See verification log below for how this was actually verified, plus a new manual scenario for a developer with a live test vault.

## Verification log

**Automated (this environment)**:
- `pytest --cov=note_watcher`: 158 passed, 90% coverage — unaffected, as expected, since no Python source was touched by this fix.
- `ruff check` / `ruff format --check`: pre-existing findings on `main` (verified via `git stash`), none introduced by this change; no lint/format issues in the files this PR touches (all YAML/Markdown).
- `actionlint` on the modified workflow file: clean.
- **Local git race simulation** (real git, two real clones, a shared bare remote — no mocks): reproduced the exact failure from the issue, then confirmed the fix resolves it.
  - *Without* the `git pull --ff-only` fix: run B's `git pull --rebase` hits `CONFLICT (content): Merge conflict in note.md` and the push is rejected — reproducing the bug.
  - *With* the fix: run B resyncs first, sees the first instruction already `@done`, only processes the second, and pushes cleanly. Final file correctly shows both instructions completed, one by each run, no duplication:
    ```
    <!-- @done echo: first task done (runA) /@done -->
    ...
    <!-- @done echo: second task done (runB) /@done -->
    ```

**Manual (requires live infra, documented for the developer)**: added VERIFICATION_PLAN.md Scenario 7, which walks through triggering two real overlapping pushes against a live test vault repo with GitHub Actions + `ANTHROPIC_API_KEY` configured, to confirm both runs go green end-to-end.

## Test plan

- [x] `pytest --cov=note_watcher` passes (158 passed, 90% coverage)
- [x] `ruff check` / `ruff format --check` show no new issues
- [x] `actionlint` passes on the modified workflow
- [x] Local git race simulation reproduces the bug on old behavior and confirms the fix
- [ ] Developer runs VERIFICATION_PLAN.md Scenario 7 against a live test vault (requires real GitHub Actions + secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)