### PR TITLE
chore: bump version to 0.4.5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   version:
     description: 'notes-watcher package version to install (e.g. "0.1.0"). Defaults to the version matching this action release; use "latest" to always install the newest release.'
     required: false
-    default: '0.4.4'
+    default: '0.4.5'
   commit:
     description: 'Whether to commit and push results automatically'
     required: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "notes-watcher"
-version = "0.4.4"
+version = "0.4.5"
 description = "A daemon that detects @ mentions in Obsidian notes, dispatches instructions to AI agents, and writes results back inline."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps the package/action version to 0.4.5 so the concurrency fix from #35 (fixes #28) ships in a pinned release, per the README's upgrade instructions for existing installations.

- `pyproject.toml`: 0.4.4 → 0.4.5
- `action.yml`: `version` input default 0.4.4 → 0.4.5, kept in sync per `tests/test_action_metadata.py`

## Test plan
- [x] `pytest tests/test_action_metadata.py` passes
- [x] Full suite: 158 passed, 90% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)